### PR TITLE
feat: Dynamic header height via CSS variables

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -63,7 +63,7 @@ body {
     background-color: var(--color-apple-gray-light);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    padding-top: 70px; /* Placeholder for fixed header height */
+    padding-top: var(--header-height, 70px); /* Dynamic header height with fallback */
 }
 
 /* Typography */
@@ -418,7 +418,7 @@ footer p { margin-bottom: 0; font-size: 0.9rem; opacity: 0.8; }
 /* Responsive Adjustments */
 /* Mobile Navigation Specifics (from previous step, ensure integration) */
 @media (max-width: 767px) {
-    body { padding-top: 60px; /* Adjust if header height changes */ }
+    body { padding-top: var(--header-height, 60px); /* Dynamic header height with fallback */ }
     header { padding: calc(var(--spacing-unit) * 0.6) 0; }
     .menu-toggle { display: flex; flex-direction: column; justify-content: center; align-items: center; }
     nav ul#navigation-menu {
@@ -485,12 +485,3 @@ nav ul li a:focus-visible, .btn:focus-visible {
     outline: none; /* Already handled by border and box-shadow */
 }
 
-/* Helper for body padding for fixed header, adjust if header height changes significantly */
-body {
-    padding-top: 70px; /* Based on new header padding, this may need adjustment */
-}
-/* Example: Measure header height in devtools and set this value.
-   If header padding: calc(var(--spacing-unit) * 0.8) 0; and spacing unit is 1rem (17px),
-   0.8 * 17 = 13.6px padding top/bottom. Add font size, etc.
-   Let's assume final header height is around 60-70px.
-*/

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -22,6 +22,20 @@ document.addEventListener('DOMContentLoaded', () => {
         return header ? header.offsetHeight : 0;
     }
 
+    // Function to update the CSS variable for header height
+    function updateHeaderHeight() {
+        const height = getHeaderHeight();
+        if (height > 0) {
+            document.documentElement.style.setProperty('--header-height', `${height}px`);
+        }
+    }
+
+    // Initialize the header height CSS variable
+    updateHeaderHeight();
+
+    // Update the header height variable when the window is resized
+    window.addEventListener('resize', updateHeaderHeight);
+
     // 2. Smooth Scrolling with Sticky Header Offset
     navLinks.forEach(link => {
         link.addEventListener('click', (e) => {


### PR DESCRIPTION
- Added JavaScript function `updateHeaderHeight()` to dynamically calculate the `<header>` element height.
- Set the calculated height to a CSS variable `--header-height` on the `document.documentElement`.
- Added a `window.resize` event listener to recalculate and update the header height when the window is resized.
- Updated `css/styles.css` to use the CSS variable `var(--header-height, 70px)` for the body padding, with a fallback.
- Updated the mobile media query in `css/styles.css` to also use the CSS variable.
- Cleaned up redundant padding configurations in `css/styles.css`.

---
*PR created automatically by Jules for task [5559867919849499411](https://jules.google.com/task/5559867919849499411) started by @bluedolphins420*