### PR TITLE
Fix body padding to use dynamic header height

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -63,7 +63,7 @@ body {
     background-color: var(--color-apple-gray-light);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    padding-top: 70px; /* Placeholder for fixed header height */
+    padding-top: var(--header-height, 70px);
 }
 
 /* Typography */
@@ -418,7 +418,7 @@ footer p { margin-bottom: 0; font-size: 0.9rem; opacity: 0.8; }
 /* Responsive Adjustments */
 /* Mobile Navigation Specifics (from previous step, ensure integration) */
 @media (max-width: 767px) {
-    body { padding-top: 60px; /* Adjust if header height changes */ }
+    body { padding-top: var(--header-height, 60px); }
     header { padding: calc(var(--spacing-unit) * 0.6) 0; }
     .menu-toggle { display: flex; flex-direction: column; justify-content: center; align-items: center; }
     nav ul#navigation-menu {
@@ -484,13 +484,3 @@ nav ul li a:focus-visible, .btn:focus-visible {
 #contact-form input:focus-visible, #contact-form textarea:focus-visible {
     outline: none; /* Already handled by border and box-shadow */
 }
-
-/* Helper for body padding for fixed header, adjust if header height changes significantly */
-body {
-    padding-top: 70px; /* Based on new header padding, this may need adjustment */
-}
-/* Example: Measure header height in devtools and set this value.
-   If header padding: calc(var(--spacing-unit) * 0.8) 0; and spacing unit is 1rem (17px),
-   0.8 * 17 = 13.6px padding top/bottom. Add font size, etc.
-   Let's assume final header height is around 60-70px.
-*/

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -22,6 +22,17 @@ document.addEventListener('DOMContentLoaded', () => {
         return header ? header.offsetHeight : 0;
     }
 
+    function updateHeaderHeight() {
+        const height = getHeaderHeight();
+        if (height > 0) {
+            document.documentElement.style.setProperty('--header-height', `${height}px`);
+        }
+    }
+
+    // Set initial header height and update on resize
+    updateHeaderHeight();
+    window.addEventListener('resize', updateHeaderHeight);
+
     // 2. Smooth Scrolling with Sticky Header Offset
     navLinks.forEach(link => {
         link.addEventListener('click', (e) => {


### PR DESCRIPTION
This commit resolves the TODO in `css/styles.css` regarding the maintenance of the body's top padding based on the fixed header height.

It introduces a JavaScript function `updateHeaderHeight()` in `js/scripts.js` that calculates the header's height dynamically and sets it as a CSS variable `--header-height`. The `body` padding in `css/styles.css` now uses this dynamic variable, ensuring it always aligns properly regardless of changes to the header size or window resizes. Redundant styles and comments have been removed.

---
*PR created automatically by Jules for task [13836324879317042203](https://jules.google.com/task/13836324879317042203) started by @bluedolphins420*